### PR TITLE
remove backquotes from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ci: deps test
 release: updatedeps test releasebin
 
 bin: deps
-	@echo "WARN: `make bin` is for debug / test builds only. Use `make release` for release builds."
+	@echo "WARN: 'make bin' is for debug / test builds only. Use 'make release' for release builds."
 	@sh -c "$(CURDIR)/scripts/build.sh"
 
 releasebin: deps


### PR DESCRIPTION
backquotes get evaluated in WARN message, replacing with simple quotes